### PR TITLE
fix blinking status bar

### DIFF
--- a/editor.c
+++ b/editor.c
@@ -2031,7 +2031,7 @@ static void _editor_init_status(editor_t* editor) {
     editor->status = bview_new(editor, NULL, 0, NULL);
     editor->status->type = MLE_BVIEW_TYPE_STATUS;
     editor->rect_status.fg = TB_WHITE;
-    editor->rect_status.bg = TB_BLACK | TB_BOLD;
+    editor->rect_status.bg = TB_BLACK;
 }
 
 // Init bviews


### PR DESCRIPTION
As mentioned in https://godoc.org/github.com/nsf/termbox-go#Attribute,
"And on some terminals applying AttrBold to background may result in
blinking text.".

Fixes: https://github.com/adsr/mle/issues/1