### PR TITLE
Use getcwd instead of get_current_dir_name

### DIFF
--- a/cmd.c
+++ b/cmd.c
@@ -1389,7 +1389,7 @@ static int _cmd_menu_ctag_cb(cmd_context_t* ctx) {
 static int _cmd_menu_browse_cb(cmd_context_t* ctx) {
     char* line;
     char* path;
-    char* cwd;
+    char cwd[PATH_MAX];
     char* corrected_path;
     bview_t* new_bview;
 
@@ -1408,7 +1408,7 @@ static int _cmd_menu_browse_cb(cmd_context_t* ctx) {
     }
 
     // Fix cwd if it changed
-    cwd = get_current_dir_name();
+    getcwd(cwd, PATH_MAX);
     if (strcmp(cwd, ctx->bview->init_cwd) != 0) {
         asprintf(&corrected_path, "%s/%s", ctx->bview->init_cwd, path);
     } else {


### PR DESCRIPTION
The usage of `get_current_dir_name` has been replaced with `getcwd`
since the first one is not supported on non-GNU platforms like on
MacOSX.