### PR TITLE
Handle Posix getopt

### DIFF
--- a/editor.c
+++ b/editor.c
@@ -1906,7 +1906,7 @@ static int _editor_init_from_args(editor_t* editor, int argc, char** argv) {
 
     cur_kmap = NULL;
     cur_syntax = NULL;
-    optind = 0;
+    optind = 1;
     while (rv == MLE_OK && (c = getopt(argc, argv, "ha:b:c:H:i:K:k:l:M:m:Nn:p:S:s:t:vw:x:y:z:")) != -1) {
         switch (c) {
             case 'h':


### PR DESCRIPTION
The GNU implementation of `getopt` permute the contents of argv as it scans,
so that eventually all the nonoptions are at the end. This doesn't happen
in FreeBSD and in MacOSX, where the BSD implementation is used.

This behaviour of the GNU implementation of `getopt` was hiding a bug since
the `optind` was initialized to zero, causing the first string of argv (the
executable name) to be interpreted as the name of the file to edit.

By default `optind` is initialized to `1` by the system (see [getopt manpage] for more
info and for a better explanation of the issue).

[getopt manpage]: https://linux.die.net/man/3/getopt