### PR TITLE
Make test suite pass on Mac OS

### DIFF
--- a/tests/func/test.sh
+++ b/tests/func/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 actual=$(
     $MLE \
@@ -16,7 +16,7 @@ actual=$(
 
 for testname in "${!expected[@]}"; do
     expected_re="${expected[$testname]}"
-    if grep -Pq "$expected_re" <<<"$actual"; then
+    if grep -Eq "$expected_re" <<<"$actual"; then
         echo -e "  \x1b[32mOK \x1b[0m $testname"
     else
         echo -e "  \x1b[31mERR\x1b[0m $testname expected=$expected_re\n\n$actual"

--- a/tests/func/test.sh
+++ b/tests/func/test.sh
@@ -14,9 +14,15 @@ actual=$(
     2>&1 >/dev/null
 );
 
+if [ "$(uname)" == "Darwin" ]; then
+    grep_args="-Eq"
+else
+    grep_args="-Pq"
+fi
+
 for testname in "${!expected[@]}"; do
     expected_re="${expected[$testname]}"
-    if grep -Eq "$expected_re" <<<"$actual"; then
+    if grep $grep_args "$expected_re" <<<"$actual"; then
         echo -e "  \x1b[32mOK \x1b[0m $testname"
     else
         echo -e "  \x1b[31mERR\x1b[0m $testname expected=$expected_re\n\n$actual"

--- a/tests/func/test_cursor.sh
+++ b/tests/func/test_cursor.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 macro='b e g i n space { enter l i n e 1 enter l i n e 2 enter } enter C-f l i n e 1 enter C-2 d'
 declare -A expected

--- a/tests/func/test_cut_copy.sh
+++ b/tests/func/test_cut_copy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 macro='f o o C-k'
 declare -A expected

--- a/tests/func/test_delete.sh
+++ b/tests/func/test_delete.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 macro='f o o enter b a r backspace backspace backspace backspace'
 declare -A expected

--- a/tests/func/test_indent_outdent.sh
+++ b/tests/func/test_indent_outdent.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # cmd_indent
 macro='h e l l o M-.'

--- a/tests/func/test_insert.sh
+++ b/tests/func/test_insert.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 macro='h e l l o enter w o r l d enter'
 declare -A expected

--- a/tests/func/test_lua.sh
+++ b/tests/func/test_lua.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 on_exit() { [ -n "$lua_script" ] && rm -f $lua_script; }
 trap on_exit EXIT
@@ -67,7 +67,7 @@ expected[observer_data]='^hello$'
 source 'test.sh'
 
 # mle.editor_register_observer
-macro='F11 h i enter M-e s e q space 1 space 5 | p a s t e space - s d , enter backspace backspace'
+macro='F11 h i enter M-e s e q space 1 space 5 | p a s t e space - s d , space - enter backspace backspace'
 cat >$lua_script <<"EOD"
 mark = nil
 in_callback = false

--- a/tests/func/test_move.sh
+++ b/tests/func/test_move.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # cmd_move_(left|right|up|down)
 macro='h e l l o enter w o r l d left up right down'

--- a/tests/func/test_multi_cursor.sh
+++ b/tests/func/test_multi_cursor.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 macro='1 0 space 2 0 space 3 0 C-r \ d + C-/ y e s C-/ /'
 declare -A expected

--- a/tests/func/test_open.sh
+++ b/tests/func/test_open.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 macro=''
 extra_opts='test_file_w_suffix test_file'

--- a/tests/func/test_search_replace.sh
+++ b/tests/func/test_search_replace.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # cmd_search
 macro='h e l l o enter w o r l d C-f h e l l o enter'

--- a/tests/func/test_shell.sh
+++ b/tests/func/test_shell.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 macro='M-e e c h o space h e l l o 4 2 enter'
 declare -A expected

--- a/tests/func/test_show_help.sh
+++ b/tests/func/test_show_help.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 macro='F2'
 declare -A expected

--- a/tests/func/test_tab.sh
+++ b/tests/func/test_tab.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 extra_opts='-t 10 -y syn_generic'
 macro='tab h e l l o'

--- a/tests/func/test_undo_redo.sh
+++ b/tests/func/test_undo_redo.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 macro='a p p l e C-z C-z'
 declare -A expected

--- a/tests/func/test_window.sh
+++ b/tests/func/test_window.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 macro='C-n'
 declare -A expected

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ -z "$MLE" ]; then
     echo "Expected MLE env var defined"
@@ -7,10 +7,15 @@ fi
 
 $MLE -v
 
-for t in $(find . -mindepth 2 -executable -type f); do
+if [ "$(uname)" == "Darwin" ]; then
+    tests=$(find $(pwd -P)/ -mindepth 2 -perm +111 -type f)
+else
+    tests=$(find $(pwd -P)/ -mindepth 2 -executable -type f)
+fi
+
+for t in $tests; do
     tshort=$(basename $t)
-    tfull=$(readlink -f $t)
-    tdir=$(dirname $tfull)
+    tdir=$(dirname $t)
     tput bold 2>/dev/null; echo TEST $tshort; tput sgr0 2>/dev/null
     pushd $tdir &>/dev/null
     ./$tshort


### PR DESCRIPTION
The current test suite make assumptions that are valid only on Linux. In
order to run the test suite on multiple platforms (e.g., Mac OS),
changes have been made to remedy the current behaviour.

- Don't assume `bash` is located in `/bin/bash`, let `/usr/bin/env`
decide where it's located.
- The `-P` flag on `grep` is not available in the BSD version. The `-E`
flag is available in both GNU Grep and the BSD version.
- The BSD version of `paste` does not implicitly use standard input if
no files are provided, explicitly tell `paste` to use standard input
using `-`.
- `find` does not have the `-executable` flag in the BSD version so we
have to fallback to using `-perm +111`. It's not equivalent, but does
the trick.
- `readlink` does not use the `-f` flag for the same purpose in the BSD
version as in the GNU version. In order to avoid problems, we're falling
back to a less elegant solution working across platforms.

I'm not an expert by any means so feel free to add suggestions as you see fit. 🙂 