### PR TITLE
Github Actions to build with Cosmopolitan Libc

### DIFF
--- a/.github/workflows/cosmo.yml
+++ b/.github/workflows/cosmo.yml
@@ -1,0 +1,43 @@
+name: Build mle with Cosmopolitan Libc
+
+on:
+  workflow_dispatch:
+  release:
+    types: [created]
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: read
+
+jobs:
+
+  release-cosmo:
+    permissions:
+      contents: write
+    name: Build release binaries for Cosmo
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@master
+      - name: setup cosmocc
+        run: |
+          sudo mkdir -p /sc
+          sudo chmod -R 0777 /sc 
+          cd /sc
+          wget https://github.com/jart/cosmopolitan/releases/download/3.3.3/cosmocc-3.3.3.zip
+          mkdir cosmo
+          cd cosmo
+          unzip ../cosmocc-3.3.3.zip
+          sudo cp ./bin/ape-x86_64.elf /usr/bin/ape
+          sudo sh -c "echo ':APE:M::MZqFpD::/usr/bin/ape:' >/proc/sys/fs/binfmt_misc/register"
+      - name: build APE binary of mle
+        run: |
+          make -j AR="/sc/cosmo/bin/cosmoar" CC="/sc/cosmo/bin/cosmocc" mle_static=1 mle_vendor=1
+      - name: push binary to github
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          files: |
+            mle

--- a/vendor/Makefile
+++ b/vendor/Makefile
@@ -1,5 +1,9 @@
 lua_cflags:=-std=c99 -Wall -Wextra -g -O3 -DLUA_USE_POSIX $(CFLAGS)
-lua_objects:=$(patsubst lua/%.c,lua/%.o,$(filter-out lua/lua.c lua/onelua.c, $(wildcard lua/*.c)))
+lua_objects:=$(addprefix lua/,\
+	lapi.o lauxlib.o lbaselib.o lcode.o lcorolib.o lctype.o ldblib.o\
+    ldebug.o ldo.o ldump.o lfunc.o lgc.o linit.o liolib.o llex.o lmathlib.o lmem.o\
+    loadlib.o lobject.o lopcodes.o loslib.o lparser.o lstate.o lstring.o lstrlib.o\
+    ltable.o ltablib.o ltests.o ltm.o lundump.o lutf8lib.o lvm.o lzio.o)
 
 pcre2_cflags:=-std=c99 -Wall -Wextra -g -O3 -DPCRE2_CODE_UNIT_WIDTH=8 -DSUPPORT_JIT -DHAVE_CONFIG_H $(CFLAGS)
 pcre2_objects:=$(addprefix pcre2/src/, \


### PR DESCRIPTION
This PR adds a Github Action to build `mle` with Cosmopolitan Libc with every release. The Action uses the `mle_vendor=1` and `mle_static=1` to build the executable (thanks for vendoring the deps :slightly_smiling_face:).
The built executable `mle` should work on `x86_64` (Linux/Windows/BSDs/MacOS) and `aarch64` (Linux/MacOS), as per the Cosmopolitan Libc [README](https://github.com/jart/cosmopolitan/tree/3.3.3?tab=readme-ov-file#support-vector).

You can view the results here: https://github.com/ahgamut/mle/releases/tag/untagged-eedccd1be03a2a502de1
(edit: https://github.com/ahgamut/mle/releases/tag/v1.7.2-cosmo). Download the `mle` executable and `chmod +x` (rename to `mle.exe` on Windows) and run from the command line.

Example screenshot from downloaded `mle`:
<img src="https://github.com/adsr/mle/assets/41098605/cabe74fe-5c6e-48b7-ae9e-33671febc8b6" width=300 height=500>


