### PR TITLE
escape browse path in `cmd_browse`

### DIFF
--- a/cmd.c
+++ b/cmd.c
@@ -850,9 +850,11 @@ int cmd_browse(cmd_context_t *ctx) {
     bview_t *menu;
     aproc_t *aproc;
     char *cmd;
-    char *browse_path;
+    char *browse_path, *browse_path_esc;
     browse_path = ctx->static_param ? ctx->static_param : "./";
-    asprintf(&cmd, "cd %s && tree --charset C -n -f -L 2 2>/dev/null", browse_path);
+    browse_path_esc = util_escape_shell_arg(browse_path, strlen(browse_path));
+    asprintf(&cmd, "cd %s && tree --charset C -n -f -L 2 2>/dev/null", browse_path_esc);
+    free(browse_path_esc);
     aproc = aproc_new(ctx->editor, ctx->bview, &(ctx->bview->aproc), cmd, 0, _cmd_aproc_bview_passthru_cb);
     free(cmd);
     if (!aproc) return MLE_ERR;

--- a/tests/func/test_browse.sh
+++ b/tests/func/test_browse.sh
@@ -22,9 +22,20 @@ trap finish EXIT
 mkdir -p adir/bdir
 touch adir/bdir/hi
 
+# setup tmpdir with space in it (should be escaped)
+mkdir -p 'a sp/b sp'
+touch 'a sp/b sp/h i'
+
 # ensure that we can browse into adir, bdir, then select hi
 # ensure path is relative to where we started
 macro='C-b C-f a d i r enter enter C-f b d i r enter enter C-f h i enter enter'
 declare -A expected
 expected[hi]='^bview.[[:digit:]]+.buffer.path=adir/bdir/hi$'
+source "$this_dir/test.sh"
+
+# ensure that we can browse into 'a sp', 'b sp', then select 'h i'
+# ensure path is relative to where we started
+macro='C-b C-f a space s p enter enter C-f b space s p enter enter C-f h space i enter enter'
+declare -A expected
+expected[hi_space]='^bview.[[:digit:]]+.buffer.path=a sp/b sp/h i$'
 source "$this_dir/test.sh"


### PR DESCRIPTION
Previously, if a directory contained a space (or other special shell characters), the shell command would fail.

Fixes #92 